### PR TITLE
Xeno first aid fix

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -42,9 +42,10 @@
 		return
 
 	if(isxeno(M))
-		if(!do_mob(user, M, SKILL_TASK_VERY_EASY / (unskilled_delay * 2), BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL))
-			M.adjustBruteLoss(heal_brute * 10)
-			M.adjustFireLoss(heal_burn * 10)
+		var/heal_amount = M.maxHealth * 0.01
+		if(do_mob(user, M, 2 SECONDS, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL))
+			M.adjustBruteLoss(-heal_amount * 10)
+			M.adjustFireLoss(-heal_amount * 10)
 			return
 
 	var/datum/limb/affecting = user.client.prefs.toggles_gameplay & RADIAL_MEDICAL ? radial_medical(target, user) : target.get_limb(user.zone_selected)

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -28,7 +28,7 @@
 	if(.)
 		return
 
-	if(!ishuman(M) || !isxeno(M))
+	if(!ishuman(M) && !isxeno(M))
 		M.balloon_alert(user, "not a humanoid")
 		return FALSE
 	var/mob/living/carbon/human/target = M


### PR DESCRIPTION
Gauze, ointment, and any other stack-based item can now heal a xenomorph for 10% of its max HP, on a 2 second timer.